### PR TITLE
fix request_cache import

### DIFF
--- a/metallum.py
+++ b/metallum.py
@@ -15,7 +15,9 @@ from urllib.parse import urlencode
 import requests_cache
 from dateutil import parser as date_parser
 from pyquery import PyQuery
-from requests_cache.core import remove_expired_responses
+
+import requests_cache
+from requests_cache import remove_expired_responses
 
 CACHE_FILE=os.path.join(tempfile.gettempdir(), 'metallum_cache')
 requests_cache.install_cache(cache_name=CACHE_FILE, expire_after=300)


### PR DESCRIPTION
the way 'request_cache' has to be imported has shifted, and needed a fix -- which many others also did in their forks